### PR TITLE
Commenting bug that crashes the admin upon login

### DIFF
--- a/graveyard.php
+++ b/graveyard.php
@@ -20,7 +20,7 @@ class GraveyardPlugin extends Plugin
     {
         return [
             'onPageNotFound' => ['onPageNotFound', 100],
-            'onGetPageTemplates' => ['onGetPageTemplates', 0],
+            //'onGetPageTemplates' => ['onGetPageTemplates', 0],
         ];
     }
     /**


### PR DESCRIPTION
When trying to login to the admin panel,this crashes, because there is no 'onGetPageTemplates'